### PR TITLE
Bug when upgrading schema: duplicate entry 'use_firstbits'

### DIFF
--- a/Abe/upgrade.py
+++ b/Abe/upgrade.py
@@ -836,7 +836,7 @@ def populate_firstbits(store):
 
 def add_keep_scriptsig(store):
     store.config['keep_scriptsig'] = "true"
-    store.save_configvar("use_firstbits")
+    store.save_configvar("keep_scriptsig")
 
 def drop_satoshi_seconds_destroyed(store):
     store.drop_column_if_exists("block_txin", "satoshi_seconds_destroyed")


### PR DESCRIPTION
I tried to upgrade to the latest abe version, but got an error regarding a duplicate key 'use_firstbits'. The attached patch seems to fix the problem.
