### PR TITLE
Implement auto-reconnection to SQL database

### DIFF
--- a/Abe/abe.py
+++ b/Abe/abe.py
@@ -224,7 +224,7 @@ class Abe:
             abe.store.rollback()
             raise
 
-        abe.store.rollback()  # Close imlicitly opened transaction.
+        abe.store.rollback()  # Close implicitly opened transaction.
 
         start_response(status, [('Content-type', page['content_type']),
                                 ('Cache-Control', 'max-age=30')])


### PR DESCRIPTION
Again a fairly untested commit on non-MySQL databases, but fixes the annoying issue where the server needs to be restarted whenever the connection to MySQL is lost. More testing on other SQL's would be great. Here's what I suggest for testing:
1. Start Abe, open a page on it (ex block or something like it, needs to retrieve data from database).
2. Restart the sql server, test reconnection works as expected by reloading the page. Reconnection should happen immediately, you should get no error on first reload.
3. Shutdown the sql server, and reload the page, you should get an error
4. Restart the sql server, test reconnection still as expected by reloading the page (like # 2)

Commit message below...

Tested against MySQL, but should work on other databases as well.

OperationalError seems to be the standard errors when initially loosing
the connection or trying a rollback() on a dead con. However if the
reconnect fails we end up with a stale cursor, and then MySQL returns a
ProgrammingError. InternalError should be used then the cursor is not
valid anymore which warrants a reconnect regardless.
