### PR TITLE
Add instructions on using compressed InnoDB tables

### DIFF
--- a/README-MYSQL.txt
+++ b/README-MYSQL.txt
@@ -53,3 +53,59 @@ You should see:
     Listening on http://localhost:2750
 
 Verify the installation by browsing the URL shown.
+
+APPENDIX A -- Using InnoDB Compressed Tables
+
+If you're using InnoDB with innodb_file_format=Barracuda and
+innodb_file_per_table=1, it is possible to save a great deal of space by
+compressing InnoDB tables. Another benefit of compression is reduced IO which
+can help when IO is the bottleneck.
+
+Compression can be done at any time, however it is desirable to do it as
+early as possible; it will take much longer to run on a fully populated
+database. Also please note that you should not compress tables while Abe is
+running.
+
+The general command to compress a table is:
+
+ALTER TABLE <table> ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=<n>;
+
+Where <n> is one of 1, 2, 4, 8 or 16.
+
+Without going into many details, the KEY_BLOCK_SIZE parameter affects both
+compression ratio and performance, and longer rows requires larger sizes as
+well. To save you the trouble, the following commands have been prepared to
+give you the greatest compression ratio. (NB: For the bigger tables the
+compression have been tested only on small subset of tables -- 1M rows.)
+
+ALTER TABLE txin ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
+ALTER TABLE txout ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
+ALTER TABLE block_txin ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
+ALTER TABLE tx ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
+ALTER TABLE block_tx ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
+ALTER TABLE pubkey ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
+ALTER TABLE block ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
+ALTER TABLE chain_candidate ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=2;
+ALTER TABLE block_next ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=2;
+
+These settings gave been tested on a MySQL database with binary-type=binary
+and default settings for firtbits and scripsig. Compression of a full Abe
+database reduced its size from 36G (37254132 KiB) down to only 17G
+(17409008 KiB), a 53% compression ratio.
+
+To test for yourself, the following bash code prints out SQL commands to
+copy each table above into a compressed table for each key size. You can
+add a "LIMIT <n>" at the end of the INSERT queries to set an upper limit on
+copied rows.
+
+for t in txin txout block_txin tx block_tx pubkey block chain_candidate block_next
+do
+    for l in 1 2 4 8 16
+    do
+        echo "CREATE TABLE ${t}_kbs$l like $t;"
+        echo "ALTER TABLE ${t}_kbs$l KEY_BLOCK_SIZE=$l ROW_FORMAT=COMPRESSED;"
+        echo "INSERT INTO ${t}_kbs$l SELECT * FROM $t;"
+    done
+done
+
+Then compare the size of your table's .ibd files for each KEY_BLOCK_SIZE.


### PR DESCRIPTION
Add some instructions on using InnoDB table compression along with
benchmarks for optimal KEY_BLOCK_SIZE for each table.

Using binary storage and default settings for firstbits and scriptsigs,
a compression ratio of over 50% has been observed by compressing the
largest tables using the appropriate key block sizes.
