### PR TITLE
Add --no-load config option

### DIFF
--- a/abe.conf
+++ b/abe.conf
@@ -61,6 +61,11 @@
 # Specify no-serve to exit immediately after importing block files:
 #no-serve
 
+# Specify no-load to start abe server without ever loading the
+# blockchain - this is useful if you have a dedicated instance loading
+# blocks into your Abe database.
+#no-load
+
 # "upgrade" tells Abe to upgrade database objects automatically after
 # code updates:
 #upgrade


### PR DESCRIPTION
no-load skips loading blocks into the database, which is useful for a
"read-only" instance meant for serving from a shared database.

This is useful when having a dedicated instance loading blocks using
the --no-serve option so that "webserver" instances never block.
