### PR TITLE
Fix handling of block shortlinks

### DIFF
--- a/Abe/abe.py
+++ b/Abe/abe.py
@@ -1356,8 +1356,8 @@ class Abe:
                 ('tx',)))
 
     def handle_b(abe, page):
-        if 'chain' in page:
-            chain = page['chain']
+        chain = page['chain']
+        if chain is not None:
             height = wsgiref.util.shift_path_info(page['env'])
             try:
                 height = int(height)


### PR DESCRIPTION
Block shortlinks returned 'page not found' because the handler didn't properly check if the chain was part of the request.
