### PR TITLE
Return page contents as list not string

### DIFF
--- a/Abe/abe.py
+++ b/Abe/abe.py
@@ -279,7 +279,7 @@ class Abe:
         content = page['template'] % tvars
         if isinstance(content, unicode):
             content = content.encode('UTF-8')
-        return content
+        return [content]
 
     def get_handler(abe, cmd):
         return getattr(abe, 'handle_' + cmd, None)


### PR DESCRIPTION
Returning content as a string causes WSGIref to iterate over it character by character and calling sendto() for each character.This takes forever for large responses like 20K transactions in an address lookup.

This does not seem to affect things returned by serve_static()
Edit: on second thought after looking at serve_static(), it may have the same problem, but I have static files mapped in directly to htdocs on the filesystem in the reverse proxy on the same machine.

Returning the content as a list fixes the issue. sendto() calls are each 8192 bytes long as seen with strace

1 char sendto() with no brackets
![abe_sendto1char](https://f.cloud.github.com/assets/2997504/2084131/4d54cfa4-8e17-11e3-88a5-dbc7f8ea7c94.PNG)

8192 chars with brackets
![abe_sendto8192char](https://f.cloud.github.com/assets/2997504/2084132/507f18a6-8e17-11e3-8eca-6d26528e6b50.PNG)
