### PR TITLE
fix public_key_to_bc_address missing version parameter

### DIFF
--- a/Abe/base58.py
+++ b/Abe/base58.py
@@ -73,7 +73,7 @@ def hash_160(public_key):
   h2 = RIPEMD160.new(h1).digest()
   return h2
 
-def public_key_to_bc_address(public_key):
+def public_key_to_bc_address(public_key, version=None):
   if not have_crypto:
     return ''
   h160 = hash_160(public_key)


### PR DESCRIPTION
called in `deserialize.extract_public_key`, function signature mismatch, raise exception when try to deserialize transaction data.
