### PR TITLE
fix JSON formatting error

### DIFF
--- a/Abe/abe.py
+++ b/Abe/abe.py
@@ -1391,11 +1391,11 @@ class Abe:
         """shows the latest blocks data in json format for datatable in chain page"""
         page['content_type'] = 'application/json'
         latest_blocks = []
-        total_number_of_blocks = abe.get_max_block_height(chain)
         post_data = get_post_data(page)
         if chain is None:
             return 'Shows latest blocks.\n' \
                 '/chain/CHAIN/q/get_latest_blocks[/INTERVAL[/START[/STOP]]]\n'
+        total_number_of_blocks = abe.get_max_block_height(chain)
         if 'sEcho' in post_data:
             sEcho_val = int( post_data['sEcho'] )
         else:
@@ -1464,7 +1464,7 @@ class Abe:
                 else:
                     percent_destroyed = '%5g%%' % (100.0 - (100.0 * ss / total_ss))
     
-                latest_blocks.append([int(height), hash, format_time(int(nTime)), int(num_tx), format_satoshis(value_out, chain),
+                latest_blocks.append([int(height), abe.store.hashout_hex(hash), format_time(int(nTime)), int(num_tx), format_satoshis(value_out, chain),
                                       util.calculate_difficulty(int(nBits)),format_satoshis(satoshis, chain), avg_age, '%5g' % (seconds / 86400.0), percent_destroyed])
                 
             return ['{"sEcho":',sEcho_val,',"iTotalRecords":',total_number_of_blocks,',"iTotalDisplayRecords":',total_number_of_blocks,',"aaData":',json.dumps(latest_blocks),'}']
@@ -1474,7 +1474,7 @@ class Abe:
     def q_get_latest_transactions(abe,page,chain):
         if chain is None:
             return 'Shows latest 10 transactions in CHAIN.\n' \
-                '/chain/CHAIN/q/getdifficulty\n'
+                '/chain/CHAIN/q/get_latest_transactions\n'
         rows = abe.store.selectall("""
             SELECT tx_id,tx_hash,tx_size
             FROM tx


### PR DESCRIPTION
1.fix browse /q/get_blocks_data directly showing Python error.
2.fix error: "DataTables warning (table id = 'chain'): DataTables warning: JSON data from server could not be parsed. This is caused by a JSON formatting error." by transfer "hash" from binary to hex.
3.fix some api words.
