### PR TITLE
Updated the README.txt installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,16 @@ Issue:
 This will install abe to your system, so after you set up the
 database (see README-*****.txt) you can run:
 
-    python -m Abe.abe --config mydbconf.conf
-        --commit-bytes 100000 --no-serve
+    python -m Abe.abe --config mydbconf.conf --commit-bytes 100000 --no-serve
     
+This will perform the initial data load and will take a lot of time.
+After it's succesfully synced, you can run the web server with: 
+
+    python -m Abe.abe --config abe-my.conf
+    
+To really get everything right see the README file for your type of
+database.
+
 Abe depends on Python 2.7 (or 2.6), the pycrypto package, and an SQL
 database supporting ROLLBACK.  Abe runs on PostgreSQL, MySQL's InnoDB
 engine, and SQLite.  Other SQL databases may work with minor changes.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ database (see README-*****.txt) you can run:
 This will perform the initial data load and will take a lot of time.
 After it's succesfully synced, you can run the web server with: 
 
-    python -m Abe.abe --config abe-my.conf
+    python -m Abe.abe --config mydbconf.conf
     
 To really get everything right see the README file for your type of
 database.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ Issue:
 
     python setup.py install
 
-or simply run Abe from the directory containing setup.py.
+This will install abe to your system, so after you set up the
+database (see README-*****.txt) you can run:
 
+    python -m Abe.abe --config mydbconf.conf
+        --commit-bytes 100000 --no-serve
+    
 Abe depends on Python 2.7 (or 2.6), the pycrypto package, and an SQL
 database supporting ROLLBACK.  Abe runs on PostgreSQL, MySQL's InnoDB
 engine, and SQLite.  Other SQL databases may work with minor changes.


### PR DESCRIPTION
The installation instructions were a little unclear to me.

I also removed the line:

"Run Abe from the directory containing setup.py"

as I tried that and didn't work and I guess it's also not a "recommended" way, right?