### PR TITLE
Use ORDER BY instead of MAX() to get last block

### DIFF
--- a/Abe/DataStore.py
+++ b/Abe/DataStore.py
@@ -2586,7 +2586,9 @@ store._ddl['txout_approx'],
         (max_height,) = store.selectrow("""
             SELECT MAX(block_height)
               FROM chain_candidate
-             WHERE chain_id = ?""", (chain.id,))
+             WHERE chain_id = ?
+             ORDER BY block_height DESC
+             LIMIT 1""", (chain.id,))
         height = 0 if max_height is None else int(max_height) + 1
 
         def get_tx(rpc_tx_hash):
@@ -2973,10 +2975,12 @@ store._ddl['txout_approx'],
 
     def get_block_number(store, chain_id):
         (height,) = store.selectrow("""
-            SELECT MAX(block_height)
+            SELECT block_height
               FROM chain_candidate
              WHERE chain_id = ?
-               AND in_longest = 1""", (chain_id,))
+               AND in_longest = 1
+             ORDER BY block_height DESC
+             LIMIT 1""", (chain_id,))
         return -1 if height is None else int(height)
 
     def get_target(store, chain_id):


### PR DESCRIPTION
@jtobey, you're clearly much more knowledgeable about SQL and portability... what do you think of this patch?

On MySQL/TokuDB the later is much faster. MAX() doesn't seem use the key at all. Using ORDER BY... LIMIT works, and hopefully will use the composite key when there are more than one chain (I tested only with one). When testing the patched query the SQL response time is pretty much instant (<1ms).

You can easily test using ab (Apache Benchmark), ex:
```
ab -n1000 http://127.0.0.1:2750/chain/Bitcoin/q/getblockcount
```

MySQL is hung at 99% cpu without the patch, and it take about 230ms per request... same command (above) with the patch is pretty awesome:
```
Requests per second:    1123.53 [#/sec] (mean)
Time per request:       0.890 [ms] (mean)
```

