### PR TITLE
Disable resolving of http client IP addresses

### DIFF
--- a/Abe/abe.py
+++ b/Abe/abe.py
@@ -1882,6 +1882,11 @@ def serve(store):
     args = store.args
     abe = Abe(store, args)
 
+    # Hack preventing wsgiref.simple_server from resolving client addresses
+    bhs = __import__('BaseHTTPServer')
+    bhs.BaseHTTPRequestHandler.address_string = lambda x: x.client_address[0]
+    del(bhs)
+
     if args.query is not None:
         def start_response(status, headers):
             pass


### PR DESCRIPTION
@jtobey do you think this patch should be bound to a configuration option or just like that? I noticed each request would hang for 2 seconds when I enabled network access to my Abe instance at home. This fixes it by replacing the reverse client IP lookup with the client IP itself (which is what the original address_string method returns on lookup failure too)