### PR TITLE
Add large number inserts to int_type tests

### DIFF
--- a/Abe/SqlAbstraction.py
+++ b/Abe/SqlAbstraction.py
@@ -860,7 +860,7 @@ class SqlAbstraction(object):
             sql.ddl("""
                 CREATE TABLE %stest_1 (
                     test_id NUMERIC(2) NOT NULL PRIMARY KEY,
-                    i1 NUMERIC(30), i2 NUMERIC(20))""" % sql.prefix)
+                    i1 NUMERIC(28), i2 NUMERIC(28), i3 NUMERIC(28))""" % sql.prefix)
             # XXX No longer needed?
             sql.ddl("""
                 CREATE VIEW %stest_v1 AS
@@ -871,9 +871,10 @@ class SqlAbstraction(object):
                   FROM %stest_1""" % (sql.prefix, sql.prefix))
             v1 = 2099999999999999
             v2 = 1234567890
-            sql.sql("INSERT INTO %stest_1 (test_id, i1, i2)"
-                    " VALUES (?, ?, ?)" % sql.prefix,
-                    (1, sql.intin(v1), v2))
+            v3 = 12345678901234567890L
+            sql.sql("INSERT INTO %stest_1 (test_id, i1, i2, i3)"
+                    " VALUES (?, ?, ?, ?)" % sql.prefix,
+                    (1, sql.intin(v1), v2, sql.intin(v3)))
             sql.commit()
             prod, o1 = sql.selectrow("SELECT i1_approx * i2, i1 FROM %stest_v1" % sql.prefix)
             prod = int(prod)


### PR DESCRIPTION
sqlite fails with a "OverflowError: long too big to convert" error when
inserting very large number, which is also fixed by using the "str"
int_type.

I haven't merged this yet as I need to make sure it doesn'T affect MySQL and pgsql first.