### PR TITLE
For backward compatibility with old pycrypto lib.

### DIFF
--- a/Abe/base58.py
+++ b/Abe/base58.py
@@ -61,7 +61,7 @@ try:
   # Needed for RIPEMD160 hash function, used to compute
   # Bitcoin addresses from internal public keys.
   import Crypto.Hash.SHA256 as SHA256
-  import Crypto.Hash.RIPEMD160 as RIPEMD160
+  import Crypto.Hash.RIPEMD as RIPEMD160
   have_crypto = True
 except ImportError:
   have_crypto = False


### PR DESCRIPTION
RIPEMD.py file in Python Crypto library exists for backward compatibility
with old code that refers to Crypto.Hash.RIPEMD, so it's more suitable to
import Crypto.Hash.RIPEMD instead of Crypto.Hash.RIPEMD160 here.