### PR TITLE
Fix stats computation bug caused by missing block_txin links

### DIFF
--- a/Abe/DataStore.py
+++ b/Abe/DataStore.py
@@ -963,8 +963,8 @@ store._ddl['txout_approx'],
         store.save_configvar(name)
 
     def cache_block(store, block_id, height, prev_id, search_id):
-        assert isinstance(block_id, int), block_id
-        assert isinstance(height, int), height
+        assert isinstance(block_id, int), repr(block_id)
+        assert isinstance(height, int), repr(height)
         assert prev_id is None or isinstance(prev_id, int)
         assert search_id is None or isinstance(search_id, int)
         block = {

--- a/Abe/verify.py
+++ b/Abe/verify.py
@@ -210,7 +210,8 @@ class AbeVerify:
             # Take out redo's from known_ids
             skip_ids = set(known_ids).difference(redo)
             self._populate_block_txin(int(block_id), skip_txin=skip_ids)
-            self.store.commit()
+            self.logger.info("block id %d: txin links repaired", block_id)
+
 
         # Record stats
         self.stats['btimiss'] += len(missing)
@@ -385,7 +386,7 @@ class AbeVerify:
                        self.store.intin(b['total_ss']),
                        self.store.intin(b['ss_destroyed']),
                        block_id))
-            self.logger.info("block %d (id %d): repaired",
+            self.logger.info("block %d (id %d): stats repaired",
                              block_height, block_id)
 
         if badcheck:
@@ -451,7 +452,7 @@ def main(argv):
     --block-stats   Check block statistics computed from prev blocks and
                     transactions
 
-  Options (can be combined):
+  Options:
     --verbose       Print all errors found (default)
     --quiet         Print only progress info and error summary
     --silent        Print nothing; no feedback beside return code

--- a/Abe/verify.py
+++ b/Abe/verify.py
@@ -353,7 +353,7 @@ class AbeVerify:
         b['total_satoshis'] = prev_satoshis + b['value_out'] \
                               - b['value_in'] - value_destroyed
 
-        if None in b.keys():
+        if None in b.values():
             raise Exception("Stats computation error: block %d (height %d): "
                             "%s" % (block_id, block_height, str(b)))
 


### PR DESCRIPTION
The `block_txin` table stores output block for a block's txins, which is then used to find the age of coins being spent. With multiple sibling blocks containing the same transactions, we sometimes tried linking against blocks that aren't our ancestors and silently skipped them.

These commits fix that and a `Abe.verify` check for both missed txins and existing txin out-block id's has been added (the latter check hasn't yet found any error from my tests; the code implies we should pick the lowest `block_height` rather than `block_id` - which is now the case - but AFAIK the `is_descended_from` check ensures only one can match already).
