### PR TITLE
Fix MySQL VARBINARY column creation

### DIFF
--- a/Abe/DataStore.py
+++ b/Abe/DataStore.py
@@ -95,10 +95,9 @@ NULL_PUBKEY_ID = 0
 PUBKEY_ID_NETWORK_FEE = NULL_PUBKEY_ID
 
 # Size of the script and pubkey columns in bytes.
-MAX_SCRIPT = 1000000
-MAX_PUBKEY = 65
-
-NO_CLOB = 'BUG_NO_CLOB'
+MAX_SCRIPT = SqlAbstraction.MAX_SCRIPT
+MAX_PUBKEY = SqlAbstraction.MAX_PUBKEY
+NO_CLOB = SqlAbstraction.NO_CLOB
 
 # XXX This belongs in another module.
 class InvalidBlock(Exception):


### PR DESCRIPTION
Some versions of MySQL/MariaDB auto-convert large VARBINARY() to BLOB,
others return errors. Knowing current MAX_SCRIPT gets converted to
MEDIUMBLOB, explicitly convert VARBINARY(MAX_SCRIPT) to MEDIUMBLOB.

Fixes #227