### PR TITLE
Stops a potential DoS by limiting maximum count to

### DIFF
--- a/Abe/abe.py
+++ b/Abe/abe.py
@@ -416,6 +416,8 @@ class Abe:
         body += abe.search_form(page)
 
         count = get_int_param(page, 'count') or 20
+        if count >= 2017:
+            count = 20
         hi = get_int_param(page, 'hi')
         orig_hi = hi
 


### PR DESCRIPTION
2016 or less. This way, you're not having memory exhausted by someone trying to load information on all of your blocks.