### PR TITLE
Fixes /chains/chain redirecting to /chains/chain/COIN

### DIFF
--- a/Abe/abe.py
+++ b/Abe/abe.py
@@ -317,7 +317,7 @@ class Abe:
                 continue
 
             body += [
-                '<tr><td><a href="chain/', escape(name), '">',
+                '<tr><td><a href="/chain/', escape(name), '">',
                 escape(name), '</a></td><td>', escape(chain.code3), '</td>']
 
             if row[1] is not None:


### PR DESCRIPTION
Going to something like https://example.com/chains/chain/ and clicking the coin name, will take you to https://example.com/chains/chain/COIN
This fix changes that to always go to https://example.com/chain/COIN