### PR TITLE
Fix both Currency and Block incorrect redirect ...

### DIFF
--- a/Abe/abe.py
+++ b/Abe/abe.py
@@ -317,7 +317,7 @@ class Abe:
                 continue
 
             body += [
-                '<tr><td><a href="chain/', escape(name), '">',
+                '<tr><td><a href="/chain/', escape(name), '">',
                 escape(name), '</a></td><td>', escape(chain.code3), '</td>']
 
             if row[1] is not None:
@@ -325,7 +325,7 @@ class Abe:
                     int(row[1]), int(row[2]), abe.store.hashout_hex(row[3]))
 
                 body += [
-                    '<td><a href="block/', hash, '">', height, '</a></td>',
+                    '<td><a href="/block/', hash, '">', height, '</a></td>',
                     '<td>', format_time(nTime), '</td>']
 
                 if row[6] is not None and row[7] is not None:


### PR DESCRIPTION
when at /chains/chain.
In regards to the currency redirect:
1. This will redirect over and over again to pages like /chains/chain/chain/CHAIN_NAME and then /chains/chain/chain/chain/CHAIN_NAME , etc etc.
In regards to the block redirect:
2. This will redirect over and over again to pages like /chains/chain/chain/block