### PR TITLE
Properly escape env['PATH_INFO'] to remedy ...

### DIFF
--- a/Abe/abe.py
+++ b/Abe/abe.py
@@ -217,7 +217,7 @@ class Abe:
             "body": [],
             "env": env,
             "params": {},
-            "dotdot": "../" * (env['PATH_INFO'].count('/') - 1),
+            "dotdot": "../" * (escape(env['PATH_INFO']).count('/') - 1),
             "start_response": start_response,
             "content_type": str(abe.template_vars['CONTENT_TYPE']),
             "template": abe.template,


### PR DESCRIPTION
this nonsense: https://github.com/bitcoin-abe/bitcoin-abe/issues/292